### PR TITLE
Wireless to open networks (no WPA/WPA2) - changes to JSON

### DIFF
--- a/mqtt/xdk2mam-c/source/sensors/Accelerometer.c
+++ b/mqtt/xdk2mam-c/source/sensors/Accelerometer.c
@@ -38,7 +38,7 @@ char* processAccelData(void * param1, uint32_t param2)
 
     if ( RETCODE_OK == Accelerometer_readXyzGValue(xdkAccelerometers_BMA280_Handle, &getaccelData))
     {
-        sprintf(buffer,"{\"sensorType\":\"Accelerometer\",\"data\":[{\"name\":\"x\",\"value\":\"%ld\"},{\"name\":\"y\",\"value\":\"%ld\"},{\"name\":\"z\",\"value\":\"%ld\"}]}",
+        sprintf(buffer,"{\"sensorType\":\"Accelerometer\",\"data\":[{\"x\":\"%ld\"},{\"y\":\"%ld\"},{\"z\":\"%ld\"}]}",
 							(long int) getaccelData.xAxisData, (long int) getaccelData.yAxisData, (long int) getaccelData.zAxisData);
     }
     else

--- a/mqtt/xdk2mam-c/source/sensors/EnvironmentalSensor.c
+++ b/mqtt/xdk2mam-c/source/sensors/EnvironmentalSensor.c
@@ -42,7 +42,7 @@ char * processEnvSensorData(void * param1, uint32_t param2)
     if ( RETCODE_OK == returnValue)
     {
 
-       sprintf(buffer,"{\"sensorType\": \"Environmental\",\"data\":[{\"name\":\"Pressure\",\"value\":\"%ld\"},{\"name\":\"Temperature\",\"value\":\"%ld\"},{\"name\":\"Humidity\",\"value\":\"%ld\"}]}",
+       sprintf(buffer,"{\"sensorType\": \"Environmental\",\"data\":[{\"Pressure\":\"%ld\"},{\"Temperature\":\"%ld\"},{\"Humidity\":\"%ld\"}]}",
         		(long int) bme280.pressure, (long int) bme280.temperature, (long int) bme280.humidity);
 
     }

--- a/mqtt/xdk2mam-c/source/sensors/Gyroscope.c
+++ b/mqtt/xdk2mam-c/source/sensors/Gyroscope.c
@@ -54,7 +54,7 @@ char* processGyroData(void * param1, uint32_t param2)
     {
 
 
-        sprintf(buffer,"{\"sensorType\":\"Gyroscope\",\"data\":[{\"name\":\"x\",\"value\":\"%ld\"},{\"name\":\"y\",\"value\":\"%ld\"},{\"name\":\"z\",\"value\":\"%ld\"}]}",
+        sprintf(buffer,"{\"sensorType\":\"Gyroscope\",\"data\":[{\"x\":\"%ld\"},{\"y\":\"%ld\"},{\"z\":\"%ld\"}]}",
 							(long int) getMdegData.xAxisData, (long int) getMdegData.yAxisData, (long int) getMdegData.zAxisData);
 
     }

--- a/mqtt/xdk2mam-c/source/sensors/InertialSensor.c
+++ b/mqtt/xdk2mam-c/source/sensors/InertialSensor.c
@@ -45,7 +45,7 @@ char* processInertiaSensor(void * param1, uint32_t param2)
     {
 
 
-        sprintf(buffer,"{\"sensorType\":\"Inertial\",\"data\":[{\"name\":\"x\",\"value\":\"%ld\"},{\"name\":\"y\",\"value\":\"%ld\"},{\"name\":\"z\",\"value\":\"%ld\"}]}",
+        sprintf(buffer,"{\"sensorType\":\"Inertial\",\"data\":[{\"x\":\"%ld\"},{\"y\":\"%ld\"},{\"z\":\"%ld\"}]}",
 							(long int) getConvData.xAxisData, (long int) getConvData.yAxisData, (long int) getConvData.zAxisData);
 
     }

--- a/mqtt/xdk2mam-c/source/sensors/LightSensor.c
+++ b/mqtt/xdk2mam-c/source/sensors/LightSensor.c
@@ -65,7 +65,7 @@ char* processLightSensorData(void * param1, uint32_t param2)
     }
     else
     {
-        sprintf(buffer,"{\"sensorType\":\"Light\",\"data\":[{\"name\":\"milliLux\",\"value\":\"%d\"}]}",
+        sprintf(buffer,"{\"sensorType\":\"Light\",\"data\":[{\"milliLux\":\"%d\"}]}",
 							(unsigned int) milliLuxData);
     }
 

--- a/mqtt/xdk2mam-c/source/sensors/Magnetometer.c
+++ b/mqtt/xdk2mam-c/source/sensors/Magnetometer.c
@@ -42,7 +42,7 @@ char* processMagnetometerData(void * param1, uint32_t param2)
     if ( RETCODE_OK == sensorApiRetValue)
     {
     	//microtesla
-        sprintf(buffer,"{\"sensorType\":\"Magnetometer\",\"data\":[{\"name\":\"x\",\"value\":\"%ld\"},{\"name\":\"y\",\"value\":\"%ld\"},{\"name\":\"z\",\"value\":\"%ld\"}]}",
+        sprintf(buffer,"{\"sensorType\":\"Magnetometer\",\"data\":[{\"x\":\"%ld\"},{\"y\":\"%ld\"},{\"z\":\"%ld\"}]}",
 							(long int) getMagData.xAxisData, (long int) getMagData.yAxisData, (long int) getMagData.zAxisData);
     }
     else

--- a/mqtt/xdk2mam-c/source/xdk2mam-mqtt.c
+++ b/mqtt/xdk2mam-c/source/xdk2mam-mqtt.c
@@ -93,17 +93,19 @@ static Retcode_T NetworkSetup(void)
 {
     Retcode_T retcode = RETCODE_OK;
     WlanConnect_SSID_T connectSSID = (WlanConnect_SSID_T) WIFI_SSID;
-    WlanConnect_PassPhrase_T connectPassPhrase =
-            (WlanConnect_PassPhrase_T) WIFI_PW;
+    WlanConnect_PassPhrase_T connectPassPhrase;
     retcode = WlanConnect_Init();
     if (retcode == RETCODE_OK)
     {
         retcode = NetworkConfig_SetIpDhcp(0);
-
     }
     if (retcode == RETCODE_OK)
     {
-        retcode = WlanConnect_WPA(connectSSID, connectPassPhrase, NULL);
+        if (WIFI_PW) {
+            connectPassPhrase = (WlanConnect_PassPhrase_T) WIFI_PW;
+            retcode = WlanConnect_WPA(connectSSID, connectPassPhrase, NULL);
+        } else
+            retcode = WlanConnect_Open(connectSSID, NULL);
     }
     if (retcode == RETCODE_OK)
     {
@@ -112,7 +114,6 @@ static Retcode_T NetworkSetup(void)
 
     return retcode;
 }
-
 
 static retcode_t SubscribeToOwnPublishTopic(void)
 {

--- a/mqtt/xdk2mam-c/source/xdk2mam-mqtt.h
+++ b/mqtt/xdk2mam-c/source/xdk2mam-mqtt.h
@@ -32,7 +32,8 @@ typedef enum{
 
 #define WIFI_SSID 			"YourWifiNetwork"
 
-#define WIFI_PW				"YourWifiPassword"
+#define WIFI_PW				"YourWifiPassword" // set to WIFI_PW 0 to use open wireless networks 
+//#define WIFI_PW				0 // WIFI_PW 0 to be used with open wireless networks 
 
 #define MQTT_BROKER_HOST	"MQTT_IP_BROKER_HOST"
 


### PR DESCRIPTION
Hello,
I edited xdk2mam-mqtt.h and xdk2mam-mqtt.c to make it possible to connect to open wireless networks (without WPA/WPA2) is `WIFI_PW 0`, or connect normally to WPA/WPA2 protected networks if `WIFI_PW "wireless-password"` is inserted. (Thanks to [Dr. Electron](https://twitter.com/Dr_Electron))

Changed all JSON like follows:

`{"xdk2mam":[{"sensorType": "Light","data":[{"name":"millilux,"value":"98479"}`

to

`{"xdk2mam":[{"sensorType": "Light","data":[{"millilux":"98479"}`